### PR TITLE
Add support for "npm run" scripts

### DIFF
--- a/src/commands.ps1
+++ b/src/commands.ps1
@@ -41,6 +41,7 @@ $cmds = @(
 	'repo',
 	'restart',
 	'root',
+	'run',
 	'run-script',
 	'search',
 	'set',

--- a/src/completions.ps1
+++ b/src/completions.ps1
@@ -37,7 +37,7 @@
 			return @();
 		}
 
-		if ($commandAst -match "npm(.cmd)?\s+run(-script)?\s") {
+		if ($commandAst.ToString() -match "npm(.cmd)?\s+run(-script)?\s*") {
 			$allScripts = Get-PackageJsonPath | Get-PackageJsonScripts -scriptFilter "$wordToComplete*"
 			$result=$allScripts | ForEach-Object {
 				# item1 is the script name, item2 is the script text (passed as tooltip)

--- a/src/completions.ps1
+++ b/src/completions.ps1
@@ -37,7 +37,7 @@
 			return @();
 		}
 
-		if ($commandAst -match "npm(.cmd)?\s+run") {
+		if ($commandAst -match "npm(.cmd)?\s+run(-script)?\s") {
 			$allScripts = Get-PackageJsonPath | Get-PackageJsonScripts -scriptFilter "$wordToComplete*"
 			$result=$allScripts | ForEach-Object {
 				# item1 is the script name, item2 is the script text (passed as tooltip)

--- a/src/completions.ps1
+++ b/src/completions.ps1
@@ -1,6 +1,51 @@
 @('npm', 'npm.cmd') | ForEach-Object {
-	Register-ArgumentCompleter -Native -CommandName $_ -ScriptBlock {
+	Register-ArgumentCompleter -Native -CommandName $_ -ScriptBlock {		
 		param($wordToComplete, $commandAst, $cursorPosition)
+
+		# Search for a file "package.json" in the current directory or parent directories 
+		function Get-PackageJsonPath {
+			[string]$packageJsonPath=$pwd;
+			while ($packageJsonPath.Length -gt 0 -and -not (Test-Path "$packageJsonPath\package.json")) {
+				# No package.json found. Look in parent directory next
+				$packageJsonPath=Split-Path $packageJsonPath -Parent
+			}
+			
+			return $packageJsonPath
+		}
+
+		function Get-PackageJsonScripts {
+			param (
+				[Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+				[string] $packageJsonPath,
+				[string] $scriptFilter
+			)
+			if ($packageJsonPath.Length -gt 0) {
+				$packageJson="$packageJsonPath/package.json"
+				$packageJsonContent = Get-Content $packageJson | ConvertFrom-Json
+				# Do we have a "script" section?
+				if ($packageJsonContent.scripts -ne $null) {
+					$allScripts=$packageJsonContent.scripts | Get-Member -MemberType NoteProperty | where Name -like "$scriptFilter" | select -ExpandProperty Name
+					$result=$allScripts | ForEach-Object {
+						# return the script name and the script text. The script text is passed as tooltip later.
+						[tuple]::Create($_, $packageJsonContent.scripts.$_)
+					}
+
+					return $result
+				}
+			}
+
+			return @();
+		}
+
+		if ($commandAst -match "npm(.cmd)?\s+run") {
+			$allScripts = Get-PackageJsonPath | Get-PackageJsonScripts -scriptFilter "$wordToComplete*"
+			$result=$allScripts | ForEach-Object {
+				# item1 is the script name, item2 is the script text (passed as tooltip)
+				[System.Management.Automation.CompletionResult]::new($_.item1, $_.item1, 'ParameterValue', $_.item2)
+			}
+
+			return $result;
+		}
 
 		. $PSScriptRoot\commands.ps1
 		$cmds |


### PR DESCRIPTION
Fixes #2

This PR adds completion to `npm run <tab>`. Reads all the scripts from package.json found in the current directory or any parent directory, filters for the completion and adds fitting script names to the completion list. The script cmd itself is placed in the tooltip (supported e.g. by Powershell ISE)